### PR TITLE
fix: resolve Shuttle deployment service selection issue

### DIFF
--- a/services/auth-gateway/src/main.rs
+++ b/services/auth-gateway/src/main.rs
@@ -1,38 +1,22 @@
-use anyhow::Context;
+// This service is now used as a library by api-gateway
+// The main function here is only for local testing if needed
 
-use shuttle_axum::ShuttleAxum;
-use shuttle_shared_db::Postgres;
+use anyhow::Context;
 use sqlx::PgPool;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-mod adapters;
-mod application;
-mod config;
-mod domain;
+pub mod adapters;
+pub mod application;
+pub mod config;
+pub mod domain;
 
-use crate::{adapters::http::routes::create_auth_router, config::AppConfig};
-use common::init_tracing;
+pub use crate::{adapters::http::routes::create_auth_router, config::AppConfig};
 
-#[shuttle_runtime::main]
-async fn main(
-    #[Postgres(local_uri = "postgres://postgres:password@localhost:5432/gamalan")] db_uri: String,
-) -> ShuttleAxum {
-    init_tracing("auth-gateway");
-
-    let config = AppConfig::new().context("Failed to load config")?;
-
-    let pool = PgPool::connect(&db_uri)
-        .await
-        .context("Failed to connect to database")?;
-
-    let verifier = Arc::new(Mutex::new(auth_clerk::JwtVerifier::new(
-        config.clerk_jwks_url,
-        config.clerk_issuer,
-        Some(config.clerk_audience),
-    )));
-
-    let app = create_auth_router(pool, verifier).await;
-
-    Ok(app.into())
+// Local testing main - not used in production deployment
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    println!("auth-gateway is now a library service used by api-gateway");
+    println!("Use 'cargo run --bin api-gateway' to run the full application");
+    Ok(())
 }

--- a/services/auth-gateway/src/main.rs
+++ b/services/auth-gateway/src/main.rs
@@ -1,10 +1,7 @@
 // This service is now used as a library by api-gateway
 // The main function here is only for local testing if needed
 
-use anyhow::Context;
-use sqlx::PgPool;
-use std::sync::Arc;
-use tokio::sync::Mutex;
+// No imports needed for simple test main
 
 pub mod adapters;
 pub mod application;

--- a/services/backlog/src/main.rs
+++ b/services/backlog/src/main.rs
@@ -1,44 +1,22 @@
-use anyhow::Context;
+// This service is now used as a library by api-gateway
+// The main function here is only for local testing if needed
 
-use shuttle_axum::ShuttleAxum;
-use shuttle_shared_db::Postgres;
+use anyhow::Context;
 use sqlx::PgPool;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tower_http::trace::TraceLayer;
 
-mod adapters;
-mod application;
-mod config;
-mod domain;
+pub mod adapters;
+pub mod application;
+pub mod config;
+pub mod domain;
 
-use crate::{adapters::http::routes::create_backlog_router, config::AppConfig};
-use common::{correlation_id_extractor, init_tracing};
+pub use crate::{adapters::http::routes::create_backlog_router, config::AppConfig};
 
-#[shuttle_runtime::main]
-async fn main(
-    #[Postgres(local_uri = "postgres://postgres:password@localhost:5432/gamalan")] db_uri: String,
-) -> ShuttleAxum {
-    init_tracing("backlog");
-
-    let config = AppConfig::new().context("Failed to load config")?;
-
-    let pool = PgPool::connect(&db_uri)
-        .await
-        .context("Failed to connect to database")?;
-
-    let verifier = Arc::new(Mutex::new(auth_clerk::JwtVerifier::new(
-        config.clerk_jwks_url,
-        config.clerk_issuer,
-        Some(config.clerk_audience),
-    )));
-
-    let app = create_backlog_router(pool, verifier)
-        .await
-        .layer(shuttle_axum::axum::middleware::from_fn(
-            correlation_id_extractor,
-        ))
-        .layer(TraceLayer::new_for_http());
-
-    Ok(app.into())
+// Local testing main - not used in production deployment
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    println!("backlog is now a library service used by api-gateway");
+    println!("Use 'cargo run --bin api-gateway' to run the full application");
+    Ok(())
 }

--- a/services/backlog/src/main.rs
+++ b/services/backlog/src/main.rs
@@ -1,11 +1,6 @@
 // This service is now used as a library by api-gateway
 // The main function here is only for local testing if needed
 
-use anyhow::Context;
-use sqlx::PgPool;
-use std::sync::Arc;
-use tokio::sync::Mutex;
-
 pub mod adapters;
 pub mod application;
 pub mod config;

--- a/services/context-orchestrator/src/main.rs
+++ b/services/context-orchestrator/src/main.rs
@@ -1,36 +1,10 @@
-use shuttle_axum::axum::{routing::get, Router};
-use shuttle_axum::ShuttleAxum;
-use tower_http::{
-    cors::{Any, CorsLayer},
-    trace::TraceLayer,
-};
+// This service is now used as a library by api-gateway
+// The main function here is only for local testing if needed
 
-#[shuttle_runtime::main]
-async fn main() -> ShuttleAxum {
-    // Simple working router for now
-    let app = Router::new()
-        .route("/", get(home))
-        .route("/health", get(health))
-        .route("/ready", get(ready))
-        .layer(
-            CorsLayer::new()
-                .allow_origin(Any)
-                .allow_methods(Any)
-                .allow_headers(Any),
-        )
-        .layer(TraceLayer::new_for_http());
-
-    Ok(app.into())
-}
-
-async fn home() -> &'static str {
-    "Salunga AI - Context Orchestrator Service"
-}
-
-async fn health() -> &'static str {
-    "OK"
-}
-
-async fn ready() -> &'static str {
-    "READY"
+// Local testing main - not used in production deployment
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    println!("context-orchestrator is now a library service used by api-gateway");
+    println!("Use 'cargo run --bin api-gateway' to run the full application");
+    Ok(())
 }

--- a/services/projects/src/main.rs
+++ b/services/projects/src/main.rs
@@ -1,44 +1,22 @@
-use anyhow::Context;
+// This service is now used as a library by api-gateway
+// The main function here is only for local testing if needed
 
-use shuttle_axum::ShuttleAxum;
-use shuttle_shared_db::Postgres;
+use anyhow::Context;
 use sqlx::PgPool;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tower_http::trace::TraceLayer;
 
-mod adapters;
-mod application;
-mod config;
-mod domain;
+pub mod adapters;
+pub mod application;
+pub mod config;
+pub mod domain;
 
-use crate::{adapters::http::routes::create_projects_router, config::AppConfig};
-use common::{enhanced_request_middleware, init_tracing};
+pub use crate::{adapters::http::routes::create_projects_router, config::AppConfig};
 
-#[shuttle_runtime::main]
-async fn main(
-    #[Postgres(local_uri = "postgres://postgres:password@localhost:5432/gamalan")] db_uri: String,
-) -> ShuttleAxum {
-    init_tracing("projects");
-
-    let config = AppConfig::new().context("Failed to load config")?;
-
-    let pool = PgPool::connect(&db_uri)
-        .await
-        .context("Failed to connect to database")?;
-
-    let verifier = Arc::new(Mutex::new(auth_clerk::JwtVerifier::new(
-        config.clerk_jwks_url,
-        config.clerk_issuer,
-        Some(config.clerk_audience),
-    )));
-
-    let app = create_projects_router(pool, verifier)
-        .await
-        .layer(shuttle_axum::axum::middleware::from_fn(
-            enhanced_request_middleware,
-        ))
-        .layer(TraceLayer::new_for_http());
-
-    Ok(app.into())
+// Local testing main - not used in production deployment
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    println!("projects is now a library service used by api-gateway");
+    println!("Use 'cargo run --bin api-gateway' to run the full application");
+    Ok(())
 }

--- a/services/projects/src/main.rs
+++ b/services/projects/src/main.rs
@@ -1,11 +1,6 @@
 // This service is now used as a library by api-gateway
 // The main function here is only for local testing if needed
 
-use anyhow::Context;
-use sqlx::PgPool;
-use std::sync::Arc;
-use tokio::sync::Mutex;
-
 pub mod adapters;
 pub mod application;
 pub mod config;

--- a/services/prompt-builder/src/main.rs
+++ b/services/prompt-builder/src/main.rs
@@ -1,44 +1,22 @@
-use anyhow::Context;
+// This service is now used as a library by api-gateway
+// The main function here is only for local testing if needed
 
-use shuttle_axum::ShuttleAxum;
-use shuttle_shared_db::Postgres;
+use anyhow::Context;
 use sqlx::PgPool;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tower_http::trace::TraceLayer;
 
-mod adapters;
-mod application;
-mod config;
-mod domain;
+pub mod adapters;
+pub mod application;
+pub mod config;
+pub mod domain;
 
-use crate::{adapters::http::routes::create_prompt_builder_router, config::AppConfig};
-use common::{correlation_id_extractor, init_tracing};
+pub use crate::{adapters::http::routes::create_prompt_builder_router, config::AppConfig};
 
-#[shuttle_runtime::main]
-async fn main(
-    #[Postgres(local_uri = "postgres://postgres:password@localhost:5432/gamalan")] db_uri: String,
-) -> ShuttleAxum {
-    init_tracing("prompt-builder");
-
-    let config = AppConfig::new().context("Failed to load config")?;
-
-    let pool = PgPool::connect(&db_uri)
-        .await
-        .context("Failed to connect to database")?;
-
-    let verifier = Arc::new(Mutex::new(auth_clerk::JwtVerifier::new(
-        config.clerk_jwks_url,
-        config.clerk_issuer,
-        Some(config.clerk_audience),
-    )));
-
-    let app = create_prompt_builder_router(pool, verifier)
-        .await
-        .layer(shuttle_axum::axum::middleware::from_fn(
-            correlation_id_extractor,
-        ))
-        .layer(TraceLayer::new_for_http());
-
-    Ok(app.into())
+// Local testing main - not used in production deployment
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    println!("prompt-builder is now a library service used by api-gateway");
+    println!("Use 'cargo run --bin api-gateway' to run the full application");
+    Ok(())
 }

--- a/services/prompt-builder/src/main.rs
+++ b/services/prompt-builder/src/main.rs
@@ -1,11 +1,6 @@
 // This service is now used as a library by api-gateway
 // The main function here is only for local testing if needed
 
-use anyhow::Context;
-use sqlx::PgPool;
-use std::sync::Arc;
-use tokio::sync::Mutex;
-
 pub mod adapters;
 pub mod application;
 pub mod config;

--- a/services/readiness/src/main.rs
+++ b/services/readiness/src/main.rs
@@ -1,44 +1,22 @@
-use anyhow::Context;
+// This service is now used as a library by api-gateway
+// The main function here is only for local testing if needed
 
-use shuttle_axum::ShuttleAxum;
-use shuttle_shared_db::Postgres;
+use anyhow::Context;
 use sqlx::PgPool;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tower_http::trace::TraceLayer;
 
-mod adapters;
-mod application;
-mod config;
-mod domain;
+pub mod adapters;
+pub mod application;
+pub mod config;
+pub mod domain;
 
-use crate::{adapters::http::routes::create_readiness_router, config::AppConfig};
-use common::{correlation_id_extractor, init_tracing};
+pub use crate::{adapters::http::routes::create_readiness_router, config::AppConfig};
 
-#[shuttle_runtime::main]
-async fn main(
-    #[Postgres(local_uri = "postgres://postgres:password@localhost:5432/gamalan")] db_uri: String,
-) -> ShuttleAxum {
-    init_tracing("readiness");
-
-    let config = AppConfig::new().context("Failed to load config")?;
-
-    let pool = PgPool::connect(&db_uri)
-        .await
-        .context("Failed to connect to database")?;
-
-    let verifier = Arc::new(Mutex::new(auth_clerk::JwtVerifier::new(
-        config.clerk_jwks_url,
-        config.clerk_issuer,
-        Some(config.clerk_audience),
-    )));
-
-    let app = create_readiness_router(pool, verifier)
-        .await
-        .layer(shuttle_axum::axum::middleware::from_fn(
-            correlation_id_extractor,
-        ))
-        .layer(TraceLayer::new_for_http());
-
-    Ok(app.into())
+// Local testing main - not used in production deployment
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    println!("readiness is now a library service used by api-gateway");
+    println!("Use 'cargo run --bin api-gateway' to run the full application");
+    Ok(())
 }

--- a/services/readiness/src/main.rs
+++ b/services/readiness/src/main.rs
@@ -1,11 +1,6 @@
 // This service is now used as a library by api-gateway
 // The main function here is only for local testing if needed
 
-use anyhow::Context;
-use sqlx::PgPool;
-use std::sync::Arc;
-use tokio::sync::Mutex;
-
 pub mod adapters;
 pub mod application;
 pub mod config;


### PR DESCRIPTION
## Summary
- Removed `#[shuttle_runtime::main]` annotations from library services to ensure api-gateway is correctly deployed
- Fixed tracing initialization conflicts with global subscribers using `std::sync::Once` guard  
- Re-commented Secrets.toml creation in CI workflow as environment variables are configured in Shuttle console
- Cleaned up unused imports from converted service main.rs files

## Root Cause
Shuttle deploys the first service with `#[shuttle_runtime::main]` annotation in workspace member order. Since auth-gateway was listed first in Cargo.toml workspace members, it was being deployed instead of api-gateway.

## Test plan
- [x] CI/CD pipeline builds successfully
- [x] All lint and format checks pass
- [x] Smart test execution passes for affected packages
- [x] Ready for Shuttle deployment testing in CI

🤖 Generated with [Claude Code](https://claude.ai/code)