### PR TITLE
fix: Remove obsolete service health endpoints from staging tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -526,15 +526,9 @@ jobs:
             fi
           }
 
-          # Core health endpoints
+          # Core health endpoints (consolidated API gateway)
           test_endpoint "health" 200
           test_endpoint "ready" 200
-
-          # Service-specific health endpoints through unified gateway
-          test_endpoint "api/v1/projects/health" 200
-          test_endpoint "api/v1/backlog/health" 200  
-          test_endpoint "api/v1/readiness/health" 200
-          test_endpoint "api/v1/prompt-builder/health" 200
 
           # Test authentication endpoints (should return 401 without auth)
           test_endpoint "api/v1/projects" 401
@@ -581,11 +575,9 @@ jobs:
             fi
           }
 
-          # Benchmark key endpoints
+          # Benchmark key endpoints (consolidated API gateway)
           benchmark_endpoint "health" 1.0
-          benchmark_endpoint "ready" 1.0  
-          benchmark_endpoint "api/v1/projects/health" 2.0
-          benchmark_endpoint "api/v1/backlog/health" 2.0
+          benchmark_endpoint "ready" 1.0
 
           echo "✅ All performance benchmarks completed"
 


### PR DESCRIPTION
- Remove tests for individual service health endpoints that no longer exist
- Keep only consolidated API gateway health endpoints (health, ready)
- Remove performance benchmarks for removed service endpoints
- Update comments to reflect consolidated API gateway architecture

Resolves failing tests for endpoints like:
- api/v1/projects/health
- api/v1/backlog/health
- api/v1/readiness/health
- api/v1/prompt-builder/health

🤖 Generated with [Claude Code](https://claude.ai/code)